### PR TITLE
Split BUILD_REQUIRES and PREREQ_PM

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,7 +18,8 @@ WriteMakefile(
 		'asa' => 0,
 		'parent' => 0,
 		'IO::String' => 0,
-
+    },
+    BUILD_REQUIRES => {
 		'Test::use::ok' => 0,
 		'Test::More' => 0.88,
     },


### PR DESCRIPTION
Test modules are not required to use the module, some they should better be listed as BUILD_REQUIRES instead of PREREQ_PM. This is relevant if you want to install IO::Handle::Util without tests (`cpanm --notest IO::Handle::Util`).
